### PR TITLE
disable https enforcement in debug mode

### DIFF
--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -145,7 +145,7 @@ open class OAuth2AuthRequest {
 	*/
 	func asURLComponents() throws -> URLComponents {
 		let comp = URLComponents(url: url, resolvingAgainstBaseURL: false)
-		guard var components = comp, "https" == components.scheme else {
+		guard var components = comp, _isDebugAssertConfiguration() || "https" == components.scheme else {
 			throw OAuth2Error.notUsingTLS
 		}
 		if .GET == method && params.count > 0 {


### PR DESCRIPTION
Found in https://alexplescan.com/posts/2016/05/03/swift-a-nicer-way-to-tell-if-your-app-is-running-in-debug-mode/

As @ajandrade said, let's hope this hack is not going to disappear in
the next version of Swift. Anyway we will need to update our
dependencies and see if all our changes still apply :)